### PR TITLE
Fix season rollover in the Games API and missing request timeouts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,10 @@ database:
 # Database Updater supports all seasons back to 2000-2001.
 api:
   max_game_ids: 20 # Only applies to game_ids input of Games API. Not the date input.
-  valid_seasons: 
+  # Older seasons to keep serving. The current season and the one before it are
+  # always accepted on top of this list, so the API survives a season rollover
+  # without an edit here. See get_valid_seasons() in src/games_api/api.py.
+  valid_seasons:
     - "2023-2024"
     - "2024-2025"
     - "2025-2026"

--- a/src/database_updater/schedule.py
+++ b/src/database_updater/schedule.py
@@ -352,7 +352,7 @@ def fetch_schedule(season, stage_logger=None):
     endpoint = NBA_API_BASE_URL.format(season=api_season)
 
     try:
-        session = requests_retry_session(timeout=10)
+        session = requests_retry_session()
         response = session.get(endpoint, headers=NBA_API_HEADERS)
         response.raise_for_status()
 

--- a/src/games_api/api.py
+++ b/src/games_api/api.py
@@ -30,6 +30,7 @@ from src.config import config
 from src.games_api.games import get_games, get_games_for_date
 from src.utils import (
     date_to_season,
+    determine_current_season,
     game_id_to_season,
     validate_date_format,
     validate_game_ids,
@@ -37,10 +38,35 @@ from src.utils import (
 
 # Configuration
 VALID_PREDICTORS = list(config["predictors"].keys())
-VALID_SEASONS = config["api"]["valid_seasons"]
+CONFIGURED_SEASONS = config["api"]["valid_seasons"]
 MAX_GAME_IDS = config["api"]["max_game_ids"]
 
 api = Blueprint("api", __name__)
+
+
+def get_valid_seasons():
+    """
+    Returns the seasons the /games endpoint will serve.
+
+    The list in config.yaml acts as a floor of older seasons to keep serving.
+    The current season and the one before it are always added, so the endpoint
+    keeps working when a new season tips off instead of rejecting every date in
+    it until someone edits config.yaml.
+
+    Evaluated per request rather than once at import, so a server left running
+    across the June 30th season boundary picks up the new season on its own.
+
+    Returns:
+        list: Seasons in 'XXXX-XXXX' format, sorted ascending.
+    """
+    seasons = set(CONFIGURED_SEASONS)
+    current_season = determine_current_season()
+    previous_start_year = int(current_season.split("-")[0]) - 1
+
+    seasons.add(current_season)
+    seasons.add(f"{previous_start_year}-{previous_start_year + 1}")
+
+    return sorted(seasons)
 
 
 @api.route("/games", methods=["GET"])
@@ -52,7 +78,7 @@ def games():
 
     Query Parameters:
     - game_ids (str): Comma-separated list of game IDs to retrieve data for. (e.g., "0042300401,0022300649"). Maximum 20 IDs allowed.
-    - date (str): Date to retrieve games for, in the format "YYYY-MM-DD". Only the 2023-2024 or 2024-2025 season is allowed.
+    - date (str): Date to retrieve games for, in the format "YYYY-MM-DD". Must fall within a valid season (see get_valid_seasons).
     - predictor (str, optional): Predictive model to use. Defaults to the default predictor set in the config.
 
     Returns:
@@ -105,12 +131,13 @@ def games():
                 return jsonify({"error": "Invalid game IDs."}), 400
 
             # Ensure all game_ids belong to the valid seasons
+            valid_seasons = get_valid_seasons()
             seasons = {game_id_to_season(game_id) for game_id in game_ids_list}
-            if not seasons.issubset(VALID_SEASONS):
+            if not seasons.issubset(valid_seasons):
                 return (
                     jsonify(
                         {
-                            "error": f"All game IDs must belong to the valid seasons: {', '.join(VALID_SEASONS)}"
+                            "error": f"All game IDs must belong to the valid seasons: {', '.join(valid_seasons)}"
                         }
                     ),
                     400,
@@ -131,11 +158,12 @@ def games():
                 )
 
             # Ensure the date belongs to the valid seasons
-            if date_to_season(date) not in VALID_SEASONS:
+            valid_seasons = get_valid_seasons()
+            if date_to_season(date) not in valid_seasons:
                 return (
                     jsonify(
                         {
-                            "error": f"Date must be within the valid seasons: {', '.join(VALID_SEASONS)}"
+                            "error": f"Date must be within the valid seasons: {', '.join(valid_seasons)}"
                         }
                     ),
                     400,

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,7 @@ up game information, validating game IDs and dates, and converting between diffe
 Core Functions:
 - lookup_basic_game_info(game_ids, db_path=DB_PATH): Retrieves basic game information for given game IDs from the database.
 - log_execution_time(average_over=None): A decorator to log the execution time of functions.
-- requests_retry_session(retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504), session=None, timeout=10): Creates an HTTP session with retry logic for handling transient errors.
+- requests_retry_session(retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504), session=None, timeout=(10, 30)): Creates an HTTP session with retry logic and a default timeout.
 - game_id_to_season(game_id, abbreviate=False): Converts a game ID to a season string.
 - validate_game_ids(game_ids): Validates game IDs.
 - validate_date_format(date): Validates that a date string is in the format "YYYY-MM-DD".
@@ -475,25 +475,50 @@ class StageLogger:
         return False  # Don't suppress exceptions
 
 
+class TimeoutHTTPAdapter(HTTPAdapter):
+    """
+    HTTPAdapter that applies a default timeout to every request sent through it.
+
+    requests only honors a timeout passed to the individual call. Assigning
+    `session.timeout` sets an attribute that requests never reads, which leaves
+    the request with no timeout at all. Injecting it at the adapter gives every
+    request a bound, so an endpoint that accepts the connection and then stops
+    responding raises instead of blocking forever.
+    """
+
+    def __init__(self, *args, timeout=None, **kwargs):
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        """Apply the default timeout unless the caller passed one explicitly."""
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = self.timeout
+        return super().send(request, **kwargs)
+
+
 def requests_retry_session(
     retries=3,
     backoff_factor=0.3,
     status_forcelist=(500, 502, 504),
     session=None,
-    timeout=10,
+    timeout=(10, 30),
 ):
     """
-    Creates a session with retry logic for handling transient HTTP errors.
+    Creates a session with retry logic and a default timeout.
 
     Args:
         retries (int): The number of retry attempts.
         backoff_factor (float): The backoff factor for retries.
         status_forcelist (tuple): A set of HTTP status codes to trigger a retry.
         session (requests.Session): An existing session to use, or None to create a new one.
-        timeout (int): The timeout for the request.
+        timeout (float or tuple): Default timeout for every request, either a
+            number of seconds or a (connect, read) pair. Individual calls can
+            still override it. NBA endpoints regularly accept a connection and
+            then stall, so without this the caller blocks indefinitely.
 
     Returns:
-        requests.Session: A session configured with retry logic.
+        requests.Session: A session configured with retry logic and a timeout.
     """
     session = session or requests.Session()
     retry = Retry(
@@ -503,10 +528,9 @@ def requests_retry_session(
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
     )
-    adapter = HTTPAdapter(max_retries=retry)
+    adapter = TimeoutHTTPAdapter(max_retries=retry, timeout=timeout)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-    session.timeout = timeout
     return session
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,3 +154,64 @@ class TestWebAppRoutes:
         """get-game-data with empty game_id should return 400."""
         response = flask_test_client.get("/get-game-data?game_id=")
         assert response.status_code == 400
+
+
+class TestValidSeasons:
+    """Tests for season validation surviving a season rollover."""
+
+    def test_current_season_is_valid(self):
+        """The current season should be valid even if config.yaml predates it."""
+        from src.games_api.api import get_valid_seasons
+        from src.utils import determine_current_season
+
+        assert determine_current_season() in get_valid_seasons()
+
+    def test_previous_season_is_valid(self):
+        """The season before the current one should stay valid."""
+        from src.games_api.api import get_valid_seasons
+        from src.utils import determine_current_season
+
+        previous_start_year = int(determine_current_season().split("-")[0]) - 1
+        assert f"{previous_start_year}-{previous_start_year + 1}" in get_valid_seasons()
+
+    def test_configured_seasons_are_preserved(self):
+        """Seasons listed in config.yaml should remain valid."""
+        from src.config import config
+        from src.games_api.api import get_valid_seasons
+
+        valid_seasons = get_valid_seasons()
+        for season in config["api"]["valid_seasons"]:
+            assert season in valid_seasons
+
+    def test_date_in_new_season_accepted_after_rollover(
+        self, monkeypatch, flask_test_client
+    ):
+        """A date in a newly started season should not be rejected as invalid.
+
+        Regression test: valid_seasons was read from config.yaml only, so every
+        date in a new season returned 400 until the file was edited by hand.
+        """
+        import src.games_api.api as api_module
+
+        monkeypatch.setattr(api_module, "determine_current_season", lambda: "2030-2031")
+
+        response = flask_test_client.get("/api/games?date=2030-12-25")
+        assert response.status_code == 200
+
+    def test_game_id_in_new_season_accepted_after_rollover(
+        self, monkeypatch, flask_test_client
+    ):
+        """A game ID from a newly started season should not be rejected."""
+        import src.games_api.api as api_module
+
+        monkeypatch.setattr(api_module, "determine_current_season", lambda: "2030-2031")
+
+        response = flask_test_client.get("/api/games?game_ids=0023000001")
+        assert response.status_code == 200
+
+    def test_season_outside_window_still_rejected(self, flask_test_client):
+        """Seasons with no data should still return a 400 rather than empty results."""
+        response = flask_test_client.get("/api/games?date=2019-12-25")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "valid seasons" in data["error"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,12 +5,18 @@ Tests for utility functions in src/utils.py.
 These are critical validation functions used throughout the pipeline.
 """
 
+import socket
+import threading
+import time
+
 import pytest
+import requests
 
 from src.utils import (
     date_to_season,
     determine_current_season,
     game_id_to_season,
+    requests_retry_session,
     validate_date_format,
     validate_game_ids,
     validate_season_format,
@@ -157,3 +163,83 @@ class TestDetermineCurrentSeason:
         assert season[4] == "-"
         year1, year2 = season.split("-")
         assert int(year2) == int(year1) + 1
+
+
+@pytest.fixture
+def stalling_server():
+    """A server that accepts connections and never sends a response."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(5)
+    accepted = []
+
+    def accept_and_stall():
+        while True:
+            try:
+                conn, _ = server.accept()
+            except OSError:
+                return
+            accepted.append(conn)  # hold the connection open, send nothing
+
+    threading.Thread(target=accept_and_stall, daemon=True).start()
+
+    yield f"http://127.0.0.1:{server.getsockname()[1]}/"
+
+    server.close()
+    for conn in accepted:
+        conn.close()
+
+
+class TestRequestsRetrySession:
+    """Tests for the timeout applied by requests_retry_session."""
+
+    def test_stalled_response_raises_instead_of_hanging(self, stalling_server):
+        """A server that never responds should raise, not block forever.
+
+        Regression test: the timeout was assigned to session.timeout, which
+        requests ignores, so the daily pipeline hung indefinitely on a stalled
+        NBA endpoint.
+        """
+        session = requests_retry_session(retries=0, timeout=(2, 2))
+
+        start = time.time()
+        with pytest.raises(requests.exceptions.RequestException):
+            session.get(stalling_server)
+        assert time.time() - start < 15
+
+    def test_default_timeout_is_applied(self, monkeypatch):
+        """The configured timeout should reach the underlying send call."""
+        from requests.adapters import HTTPAdapter
+
+        captured = {}
+
+        def fake_send(self, request, **kwargs):
+            captured.update(kwargs)
+            raise requests.exceptions.ConnectionError("stop here")
+
+        monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+        session = requests_retry_session(timeout=(3, 7))
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get("http://127.0.0.1:1/")
+
+        assert captured["timeout"] == (3, 7)
+
+    def test_explicit_timeout_overrides_default(self, monkeypatch):
+        """A timeout passed to the call should win over the session default."""
+        from requests.adapters import HTTPAdapter
+
+        captured = {}
+
+        def fake_send(self, request, **kwargs):
+            captured.update(kwargs)
+            raise requests.exceptions.ConnectionError("stop here")
+
+        monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+        session = requests_retry_session(timeout=(3, 7))
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get("http://127.0.0.1:1/", timeout=1)
+
+        assert captured["timeout"] == 1


### PR DESCRIPTION
## 1. The Games API rejects the current season

The list of seasons the API will serve is written by hand in `config.yaml`, and it ends at 2025-2026. So any date in the new 2026-2027 season is turned away:

```
GET /api/games?date=2026-10-21
400  Date must be within the valid seasons: 2023-2024, 2024-2025, 2025-2026
```

This breaks every year when a new season starts, and stays broken until someone edits the file by hand.

**What I changed:** the list in `config.yaml` now acts as a floor. The current season and the one before it are always allowed on top of it.

- Nothing that worked before stops working.
- Old seasons with no data still return 400, so you still get a clear error instead of a silently empty result.
- The list is worked out on each request, so a server left running through the season change picks up the new season by itself.

I looked at reading the seasons from the database instead. That turned out worse: the starter database only holds the current season, so it would have cut the list down to one season and started rejecting the 2024-2025 game IDs the existing tests use.

## 2. NBA API calls have no timeout, so the pipeline can hang forever

`requests_retry_session()` set its timeout like this:

```python
session.timeout = timeout   # requests never reads this
```

A timeout in `requests` only counts if it is passed to the request itself. Setting it on the session does nothing, so every call made through this session had no timeout at all.

NBA's servers sometimes accept a connection and then send nothing back. When that happens the daily pipeline stops dead and never recovers. I hit this on a real run: it sat on a single open socket for over four minutes with no output and no way to finish.

**What I changed:** a small `TimeoutHTTPAdapter` puts the timeout where `requests` actually reads it. The default is 10 seconds to connect and 30 seconds to read, and any caller can still pass its own.

`pbp.py` and `players.py` already call `requests_retry_session()` with no arguments, so they get the timeout without those files changing at all.

## Trying it yourself

```bash
python start_app.py
curl "http://127.0.0.1:5000/api/games?date=2026-10-21"   # 200 before: 400
curl "http://127.0.0.1:5000/api/games?date=2019-12-25"   # still 400, as it should be
```
