### PR TITLE
Add a calendar date picker to the games page

### DIFF
--- a/src/games_api/games.py
+++ b/src/games_api/games.py
@@ -266,6 +266,67 @@ def get_games_for_date(date, predictor=DEFAULT_PREDICTOR):
     return games
 
 
+def get_game_counts_by_date(month):
+    """
+    Counts the games on each date of a month, for the calendar date picker.
+
+    Games are bucketed by their Eastern Time date, matching how
+    get_games_for_date selects games, so the calendar can never disagree with
+    the table it navigates to.
+
+    Args:
+        month (str): The month to count games for, as 'YYYY-MM'.
+
+    Returns:
+        dict: Maps 'YYYY-MM-DD' to the number of games on that date. Dates with
+              no games are omitted.
+
+    Raises:
+        ValueError: If the month is not in 'YYYY-MM' format.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    import pytz
+
+    try:
+        year_str, month_str = month.split("-")
+        year, month_number = int(year_str), int(month_str)
+        first_day = datetime(year, month_number, 1)
+    except (AttributeError, ValueError):
+        raise ValueError("Invalid month format. Please use YYYY-MM format.")
+
+    eastern = pytz.timezone("US/Eastern")
+
+    # The ET day boundaries of the month, converted to the UTC range stored in the DB.
+    start_of_month_et = eastern.localize(first_day)
+    if month_number == 12:
+        next_month = datetime(year + 1, 1, 1)
+    else:
+        next_month = datetime(year, month_number + 1, 1)
+    end_of_month_et = eastern.localize(next_month)
+
+    start_utc = start_of_month_et.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    end_utc = end_of_month_et.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT date_time_utc FROM Games WHERE date_time_utc >= ? AND date_time_utc < ?",
+            (start_utc, end_utc),
+        )
+        rows = cursor.fetchall()
+
+    counts = {}
+    for (date_time_utc,) in rows:
+        # Convert each game's UTC tip-off back to the ET date it belongs to.
+        parsed = datetime.strptime(date_time_utc[:19], "%Y-%m-%dT%H:%M:%S")
+        game_date = parsed.replace(tzinfo=timezone.utc).astimezone(eastern).date()
+        date_key = game_date.strftime("%Y-%m-%d")
+        counts[date_key] = counts.get(date_key, 0) + 1
+
+    return counts
+
+
 def main():
     """
     Main function to demonstrate the usage of the get_games and get_games_for_date functions.

--- a/src/web_app/app.py
+++ b/src/web_app/app.py
@@ -26,7 +26,11 @@ from flask import Flask, flash, jsonify, render_template, request
 
 from src.config import config
 from src.games_api.api import api as api_blueprint
-from src.games_api.games import get_games, get_games_for_date
+from src.games_api.games import (
+    get_game_counts_by_date,
+    get_games,
+    get_games_for_date,
+)
 from src.web_app.dashboard import dashboard as dashboard_blueprint
 from src.utils import validate_date_format
 from src.web_app.game_data_processor import get_user_datetime, process_game_data
@@ -94,6 +98,33 @@ def create_app(predictor):
             prev_date=prev_date_str,
             next_date=next_date_str,
         )
+
+    @app.route("/game-dates")
+    def game_dates():
+        """
+        Reports how many games fall on each date of a month.
+
+        Used by the date picker calendar to mark which days have games.
+
+        Query Parameters:
+        - month (str): The month to look up, as 'YYYY-MM'. Defaults to the
+          current month.
+
+        Returns:
+            Response: JSON object mapping 'YYYY-MM-DD' to a game count.
+        """
+        month = request.args.get("month")
+        if not month:
+            month = get_user_datetime(as_eastern_tz=False).strftime("%Y-%m")
+
+        try:
+            return jsonify(get_game_counts_by_date(month))
+        except ValueError as e:
+            logging.warning("Bad month in game_dates: %s", e)
+            return jsonify({"error": "Invalid month. Expected YYYY-MM."}), 400
+        except Exception:
+            logging.exception("Error in game_dates")
+            return jsonify({"error": "Internal server error"}), 500
 
     @app.route("/get-game-data")
     def get_game_data():

--- a/src/web_app/static/css/custom.css
+++ b/src/web_app/static/css/custom.css
@@ -80,3 +80,207 @@
 .pred-wrong {
     color: #cf222e !important;
 }
+
+/* Date navigation bar */
+.date-nav {
+    display: flex;
+    justify-content: center;
+}
+
+.date-nav-arrow,
+.date-nav-current {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #dee2e6;
+    background-color: #fff;
+    color: #0d6efd;
+    padding: 0.5rem 1rem;
+    line-height: 1.5;
+    text-decoration: none;
+}
+
+.date-nav-arrow:first-child {
+    border-radius: 0.375rem 0 0 0.375rem;
+}
+
+.date-nav-arrow:last-child {
+    border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.date-nav-arrow:hover {
+    background-color: #f8f9fa;
+}
+
+.date-nav-current {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+    color: #fff;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.date-nav-current:hover {
+    background-color: #0b5ed7;
+    border-color: #0b5ed7;
+}
+
+.date-nav-arrow:focus-visible,
+.date-nav-current:focus-visible,
+.date-picker-day:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+}
+
+/* Calendar date picker */
+.date-picker {
+    position: relative;
+    display: inline-flex;
+}
+
+.date-picker-panel {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    width: 300px;
+    max-width: calc(100vw - 24px);
+    padding: 12px;
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 0.5rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.date-picker-panel[hidden] {
+    display: none;
+}
+
+.date-picker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.date-picker-month {
+    font-weight: 600;
+}
+
+.date-picker-nav {
+    border: none;
+    background-color: transparent;
+    color: #495057;
+    padding: 4px 8px;
+    border-radius: 0.375rem;
+    cursor: pointer;
+}
+
+.date-picker-nav:hover {
+    background-color: #f1f3f5;
+}
+
+.date-picker-weekdays,
+.date-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+}
+
+.date-picker-weekdays span {
+    text-align: center;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #868e96;
+    padding-bottom: 4px;
+}
+
+.date-picker-day {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    color: #212529;
+    text-decoration: none;
+}
+
+.date-picker-day.is-empty {
+    visibility: hidden;
+}
+
+.date-picker-day:hover {
+    background-color: #e7f1ff;
+}
+
+/* Days with games get a dot; days without are dimmed */
+.date-picker-day.has-games::after {
+    content: "";
+    position: absolute;
+    bottom: 5px;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: #0d6efd;
+}
+
+.date-picker-day.no-games {
+    color: #adb5bd;
+}
+
+.date-picker-day.is-today {
+    box-shadow: inset 0 0 0 1px #0d6efd;
+}
+
+.date-picker-day.is-selected,
+.date-picker-day.is-selected:hover {
+    background-color: #0d6efd;
+    color: #fff;
+    font-weight: 600;
+}
+
+.date-picker-day.is-selected::after {
+    background-color: #fff;
+}
+
+.date-picker-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #f1f3f5;
+    font-size: 0.78rem;
+    color: #868e96;
+}
+
+.date-picker-legend {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.date-picker-dot {
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: #0d6efd;
+}
+
+.date-picker-today {
+    border: none;
+    background-color: transparent;
+    color: #0d6efd;
+    font-size: 0.78rem;
+    padding: 2px 6px;
+    border-radius: 0.375rem;
+    cursor: pointer;
+}
+
+.date-picker-today:hover {
+    background-color: #e7f1ff;
+}

--- a/src/web_app/static/js/main.js
+++ b/src/web_app/static/js/main.js
@@ -351,9 +351,224 @@ function showGameDetails(gameId) {
     });
 }
 
+/**
+ * Sets up the calendar date picker attached to the current-date button.
+ *
+ * Days that have games are marked with a dot, days without are dimmed, so the
+ * whole month can be scanned at a glance. Counts come from /game-dates and are
+ * cached per month.
+ */
+function initDatePicker() {
+  const toggle = document.getElementById("datePickerToggle");
+  const panel = document.getElementById("datePickerPanel");
+  const grid = document.getElementById("calGrid");
+  const monthLabel = document.getElementById("calMonthLabel");
+
+  if (!toggle || !panel || !grid) {
+    return;
+  }
+
+  const MONTH_NAMES = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+
+  const monthCache = {};
+  const selectedDateStr = document.body.dataset.queryDate;
+
+  /**
+   * Splits a "YYYY-MM-DD" string into numeric parts.
+   *
+   * Done by hand because new Date("YYYY-MM-DD") is parsed as UTC, which lands
+   * on the previous day for anyone west of Greenwich.
+   */
+  function parseDateStr(str) {
+    const parts = str.split("-").map(Number);
+    return { year: parts[0], month: parts[1] - 1, day: parts[2] };
+  }
+
+  function formatDateStr(year, month, day) {
+    const paddedMonth = String(month + 1).padStart(2, "0");
+    const paddedDay = String(day).padStart(2, "0");
+    return `${year}-${paddedMonth}-${paddedDay}`;
+  }
+
+  function monthKey(year, month) {
+    return `${year}-${String(month + 1).padStart(2, "0")}`;
+  }
+
+  const selected = parseDateStr(selectedDateStr);
+  const now = new Date();
+  const todayStr = formatDateStr(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+
+  let viewYear = selected.year;
+  let viewMonth = selected.month;
+
+  /**
+   * Loads game counts for a month, caching the result.
+   * A failed lookup resolves to no counts, so the calendar still opens.
+   */
+  function fetchMonthCounts(year, month) {
+    const key = monthKey(year, month);
+
+    if (monthCache[key]) {
+      return Promise.resolve(monthCache[key]);
+    }
+
+    return fetch(`/game-dates?month=${key}`)
+      .then((response) => (response.ok ? response.json() : {}))
+      .then((counts) => {
+        monthCache[key] = counts || {};
+        return monthCache[key];
+      })
+      .catch((error) => {
+        console.error("Error fetching game dates:", error);
+        return {};
+      });
+  }
+
+  function renderCalendar() {
+    monthLabel.textContent = `${MONTH_NAMES[viewMonth]} ${viewYear}`;
+
+    const counts = monthCache[monthKey(viewYear, viewMonth)] || {};
+    const firstWeekday = new Date(viewYear, viewMonth, 1).getDay();
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+
+    grid.innerHTML = "";
+
+    // Blank cells so the 1st lands on the right weekday
+    for (let i = 0; i < firstWeekday; i++) {
+      const filler = document.createElement("span");
+      filler.className = "date-picker-day is-empty";
+      grid.appendChild(filler);
+    }
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const dateStr = formatDateStr(viewYear, viewMonth, day);
+      const gameCount = counts[dateStr] || 0;
+
+      const cell = document.createElement("a");
+      cell.className = "date-picker-day";
+      cell.href = `/?date=${dateStr}`;
+      cell.textContent = day;
+
+      if (gameCount > 0) {
+        cell.classList.add("has-games");
+        cell.title = `${gameCount} game${gameCount === 1 ? "" : "s"}`;
+        cell.setAttribute("aria-label", `${dateStr}, ${gameCount} games`);
+      } else {
+        cell.classList.add("no-games");
+        cell.setAttribute("aria-label", `${dateStr}, no games`);
+      }
+
+      if (dateStr === todayStr) {
+        cell.classList.add("is-today");
+      }
+
+      if (dateStr === selectedDateStr) {
+        cell.classList.add("is-selected");
+        cell.setAttribute("aria-current", "date");
+      }
+
+      grid.appendChild(cell);
+    }
+  }
+
+  /**
+   * Shows a month, painting immediately and repainting once counts arrive.
+   * The repaint is skipped if the user moved on, so a slow response for an
+   * old month cannot overwrite the month now on screen.
+   */
+  function showMonth(year, month) {
+    viewYear = year;
+    viewMonth = month;
+    renderCalendar();
+
+    fetchMonthCounts(year, month).then(() => {
+      if (viewYear === year && viewMonth === month) {
+        renderCalendar();
+      }
+    });
+  }
+
+  function openPanel() {
+    panel.hidden = false;
+    toggle.setAttribute("aria-expanded", "true");
+    showMonth(selected.year, selected.month);
+  }
+
+  function closePanel() {
+    panel.hidden = true;
+    toggle.setAttribute("aria-expanded", "false");
+  }
+
+  toggle.addEventListener("click", function (event) {
+    event.stopPropagation();
+    if (panel.hidden) {
+      openPanel();
+    } else {
+      closePanel();
+    }
+  });
+
+  document
+    .getElementById("calPrevMonth")
+    .addEventListener("click", function () {
+      const month = viewMonth - 1;
+      showMonth(month < 0 ? viewYear - 1 : viewYear, (month + 12) % 12);
+    });
+
+  document
+    .getElementById("calNextMonth")
+    .addEventListener("click", function () {
+      const month = viewMonth + 1;
+      showMonth(month > 11 ? viewYear + 1 : viewYear, month % 12);
+    });
+
+  document.getElementById("calToday").addEventListener("click", function () {
+    window.location.href = `/?date=${todayStr}`;
+  });
+
+  // Close when clicking away or pressing Escape
+  document.addEventListener("click", function (event) {
+    if (
+      !panel.hidden &&
+      !panel.contains(event.target) &&
+      !toggle.contains(event.target)
+    ) {
+      closePanel();
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape" && !panel.hidden) {
+      closePanel();
+      toggle.focus();
+    }
+  });
+
+  // Warm the cache so the first open already shows the dots
+  fetchMonthCounts(selected.year, selected.month);
+}
+
 // Initialize event listeners after DOM content is fully loaded
 document.addEventListener("DOMContentLoaded", function () {
   fetchAndUpdateGames();
+  initDatePicker();
 
   document
     .querySelector("#gamesTableBody")

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -89,24 +89,46 @@
     </div>
     <!-- End of Main Games Table -->
 
-    <!-- Start of Pagination Controls -->
-    <nav aria-label="Page navigation" class="mt-4">
-        <ul class="pagination justify-content-center">
-            <!-- Previous Page Link -->
-            <li class="page-item">
-                <a class="page-link" href="/?date={{ prev_date }}">&lt;&lt;</a>
-            </li>
-            <!-- Current Page Indicator -->
-            <li class="page-item active">
-                <span class="page-link">{{ query_date_display_str }}</span>
-            </li>
-            <!-- Next Page Link -->
-            <li class="page-item">
-                <a class="page-link" href="/?date={{ next_date }}">&gt;&gt;</a>
-            </li>
-        </ul>
+    <!-- Start of Date Navigation -->
+    <nav aria-label="Date navigation" class="mt-4">
+        <div class="date-nav">
+            <!-- Previous Day -->
+            <a class="date-nav-arrow" href="/?date={{ prev_date }}" aria-label="Previous day">&lt;&lt;</a>
+
+            <!-- Current Date / Calendar Toggle -->
+            <div class="date-picker">
+                <button type="button" id="datePickerToggle" class="date-nav-current" aria-haspopup="dialog"
+                    aria-expanded="false">
+                    <i class="bi bi-calendar3 me-2"></i>{{ query_date_display_str }}
+                </button>
+
+                <!-- Calendar Panel -->
+                <div id="datePickerPanel" class="date-picker-panel" role="dialog" aria-label="Choose a date" hidden>
+                    <div class="date-picker-header">
+                        <button type="button" class="date-picker-nav" id="calPrevMonth" aria-label="Previous month">
+                            <i class="bi bi-chevron-left"></i>
+                        </button>
+                        <span class="date-picker-month" id="calMonthLabel" aria-live="polite"></span>
+                        <button type="button" class="date-picker-nav" id="calNextMonth" aria-label="Next month">
+                            <i class="bi bi-chevron-right"></i>
+                        </button>
+                    </div>
+                    <div class="date-picker-weekdays" aria-hidden="true">
+                        <span>Su</span><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span>
+                    </div>
+                    <div class="date-picker-grid" id="calGrid"></div>
+                    <div class="date-picker-footer">
+                        <span class="date-picker-legend"><span class="date-picker-dot"></span>has games</span>
+                        <button type="button" class="date-picker-today" id="calToday">Today</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Next Day -->
+            <a class="date-nav-arrow" href="/?date={{ next_date }}" aria-label="Next day">&gt;&gt;</a>
+        </div>
     </nav>
-    <!-- End of Pagination Controls -->
+    <!-- End of Date Navigation -->
 
 
     <!-- Start of Game Details Modal -->

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,3 +154,53 @@ class TestWebAppRoutes:
         """get-game-data with empty game_id should return 400."""
         response = flask_test_client.get("/get-game-data?game_id=")
         assert response.status_code == 400
+
+
+class TestGameDatesEndpoint:
+    """Tests for /game-dates, which drives the calendar date picker."""
+
+    def test_returns_counts_for_month(self, flask_test_client):
+        """Should return a mapping of dates in the month to game counts."""
+        response = flask_test_client.get("/game-dates?month=2026-01")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert isinstance(data, dict)
+        for date_str, count in data.items():
+            assert date_str.startswith("2026-01")
+            assert len(date_str) == 10
+            assert isinstance(count, int)
+            assert count > 0
+
+    def test_defaults_to_current_month(self, flask_test_client):
+        """Omitting the month should fall back to the current month."""
+        response = flask_test_client.get("/game-dates")
+        assert response.status_code == 200
+        assert isinstance(response.get_json(), dict)
+
+    def test_month_without_games_is_empty(self, flask_test_client):
+        """A month with no games should return an empty mapping, not an error."""
+        response = flask_test_client.get("/game-dates?month=1990-01")
+        assert response.status_code == 200
+        assert response.get_json() == {}
+
+    @pytest.mark.parametrize("bad_month", ["bogus", "2026-13", "2026", "2026-01-15"])
+    def test_invalid_month_returns_error(self, flask_test_client, bad_month):
+        """A malformed month should return 400 rather than a stack trace."""
+        response = flask_test_client.get(f"/game-dates?month={bad_month}")
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_counts_match_games_for_date(self, flask_test_client):
+        """The calendar must agree with the table it sends the user to.
+
+        Both bucket games by Eastern Time date; if they ever diverge, a day
+        would show a dot and then load an empty table.
+        """
+        from src.games_api.games import get_games_for_date
+
+        counts = flask_test_client.get("/game-dates?month=2026-01").get_json()
+
+        for date_str, count in sorted(counts.items())[:3]:
+            games = get_games_for_date(date_str, predictor="Baseline")
+            assert len(games) == count, f"mismatch on {date_str}"


### PR DESCRIPTION
Right now the only way to change the date is one day at a time with `<<` and `>>`. Jumping to a specific date means a lot of clicking, or editing the URL by hand.

This adds a calendar. Click the date and pick a day. Days that have games are marked with a dot, so you can see a whole month at a glance.

<img width="413" height="455" alt="Ghostty 2026-08-12 15 15 59" src="https://github.com/user-attachments/assets/205b1f20-68c3-4d7c-8be0-7fa524af1983" />

## What changed

### The date picker

`<<` and `>>` still work the same way. The date in the middle is now a button that opens the calendar.

- Days with games get a dot. Days without are greyed out, but you can still click them.
- Today has an outline. The selected day is filled in.
- Arrows move between months, and there is a "Today" shortcut.
- Closes on Escape or a click outside.

No new libraries. Plain JavaScript and the Bootstrap that has already been loaded.
